### PR TITLE
add `refresh_ns` value

### DIFF
--- a/cep-repodata-state.md
+++ b/cep-repodata-state.md
@@ -52,7 +52,7 @@ Both mamba and conda currently use the same cache folder. If both don't implemen
     // The header values as before
     "url": STRING,
     "etag": STRING,
-    "last_modified": STRING,
+    "mod": STRING,
     "cache_control": STRING,
 
     // Hash of the cached-on-disk repodata.json. In Python: hashlib.blake2b(digest_size=32)
@@ -78,7 +78,19 @@ Both mamba and conda currently use the same cache folder. If both don't implemen
         // same format as `has_zst`
     },
 
-    "jlap": { } // unspecified additional state for jlap when available
+    "jlap": {
+        // Intermediate checksum leading the second-to-last line of repodata.jlap
+        "iv": "9448c699e681ee71b4bd524f73a0b690c387df7e9f0ea2bb7ffa24af1c8c27ca",
+        // Offset of the start of the second-to-last line of repodata.jlap in bytes
+        "pos": 4226360,
+        // Last json line of repodata.jlap, before the trailing checksum
+        "footer": {
+            "url": "repodata.json",
+            "latest": "3384620e0f2bf70a418a56db98785dda530b503990e32b68afb11f27e0324d7
+    5"
+        }
+        // Other keys may appear e.g. for debugging
+    }
 }
 ```
 

--- a/cep-repodata-state.md
+++ b/cep-repodata-state.md
@@ -42,6 +42,12 @@ Both mamba and conda currently use the same cache folder. If both don't implemen
     "mtime_ns": INTEGER,
     "size": INTEGER, // file size in bytes
 
+    // most recent remote request e.g. "304 Not Modified", instead
+    // of touching the cached repodata.json file.
+    // compare with `cache_control: max-age=`.
+    // nanosecond-resolution UNIX timestamp.
+    "refresh_ns": INTEGER,
+
     // The header values as before
     "url": STRING,
     "etag": STRING,
@@ -69,7 +75,9 @@ Both mamba and conda currently use the same cache folder. If both don't implemen
 }
 ```
 
-If the `state.json` file_mtime or file_size does not match the `.json` file actual `mtime`, the header values are discarded. However, the `has_zst` or `has_jlap` values are kept as they are independent from the repodata validity on disk.
+If the `state.json` `mtime_ns` or `size` do not match the `.json` file the
+header values are discarded. However, the `has_zst` or `has_jlap` values are kept as
+they are independent from the repodata validity on disk.
 
 If the client is tracking `repodata.json.zst` or `repodata.jlap` instead of
 `(current_)?repodata.json`, then `etag`/`mod`/`cache_control` will correspond to

--- a/cep-repodata-state.md
+++ b/cep-repodata-state.md
@@ -100,6 +100,7 @@ both the `info.json` and `.json` files. It may or may not additionally lock the
 `.json` file. If the lock fails, neither file is changed.
 
 [A Python implementation](https://github.com/conda/conda/blob/main/conda/gateways/repodata/lock.py)
+[Mamba's LockFile class](https://github.com/mamba-org/mamba/blob/main/libmamba/include/mamba/core/util.hpp#L167)
 
 This minimal scheme only helps to prevent the cache from being corrupted.
 Additional locking would be neded to make it "advisable" to run multiple


### PR DESCRIPTION
IMO locking is cleaner if the cached repodata.json is not touched unless the content is changed, e.g. not touched after a 304 Not Modified response. Instead, if `refresh_ns` is more than `cache-control: max-age=n` seconds ago (if the server provided that header), or the `local_repodata_ttl` in `~/.condarc`, then it's time to do another remote request.