### PR TITLE
Update schema Python script and regenerate schema

### DIFF
--- a/cep-0027.md
+++ b/cep-0027.md
@@ -164,7 +164,9 @@ An example of a compliant statement is provided below:
 {
   "$defs": {
     "CondaPublishAttestationPredicate": {
-      "description": "Predicate for conda publish attestations.\n\nThis represents the predicate portion of an in-toto statement for conda package\npublish attestations, as defined in CEP-0027.",
+      "$id": "https://schemas.conda.org/attestations/publish/v1",
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "description": "Predicate schema for conda publish attestations. This schema defines the structure of the predicate field in an in-toto statement for conda package publish attestations.",
       "properties": {
         "targetChannel": {
           "description": "The channel where the package is being uploaded to. This must be a valid URL with no trailing slashes.",
@@ -182,7 +184,7 @@ An example of a compliant statement is provided below:
       "required": [
         "targetChannel"
       ],
-      "title": "CondaPublishAttestationPredicate",
+      "title": "Conda Publish Attestation Predicate",
       "type": "object"
     },
     "ResourceDescriptor": {

--- a/cep-0027.md
+++ b/cep-0027.md
@@ -310,10 +310,10 @@ class CondaPublishAttestationPredicate(BaseModel):
     )
 
     class Config:
-        # Allow field aliases (camelCase in JSON, snake_case in Python)
-        allow_population_by_field_name = True
+        # Allow field population by both name and alias (camelCase in JSON, snake_case in Python)
+        validate_by_name = True
         # Generate schema with field aliases
-        schema_extra = {
+        json_schema_extra = {
             "$schema": "https://json-schema.org/draft/2020-12/schema",
             "$id": "https://schemas.conda.org/attestations/publish/v1",
             "title": "Conda Publish Attestation Predicate",
@@ -428,12 +428,12 @@ class CondaPublishAttestationStatement(BaseModel):
     )
 
     class Config:
-        allow_population_by_field_name = True
+        validate_by_name = True
 
 
 def generate_predicate_schema() -> dict:
     """Generate the JSON schema for the conda publish attestation predicate."""
-    schema = CondaPublishAttestationPredicate.schema()
+    schema = CondaPublishAttestationPredicate.model_json_schema()
 
     # Update the schema to match the CEP requirements
     schema.update({
@@ -453,7 +453,7 @@ def generate_predicate_schema() -> dict:
 
 def generate_complete_statement_schema() -> dict:
     """Generate the JSON schema for the complete in-toto statement."""
-    return CondaPublishAttestationStatement.schema()
+    return CondaPublishAttestationStatement.model_json_schema()
 
 
 if __name__ == "__main__":

--- a/cep-0027.md
+++ b/cep-0027.md
@@ -273,6 +273,14 @@ An example of a compliant statement is provided below:
 
 ```py
 #!/usr/bin/env python
+#
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#     "pydantic>=2.11",
+# ]
+# ///
+#
 """
 Pydantic model for the conda publish attestation predicate schema.
 This generates the JSON schema for https://schemas.conda.org/attestations/publish/v1


### PR DESCRIPTION
This makes a couple of changes to the Python script used to generate the JSON schema (see each commit):

* Add [inline metadata](https://peps.python.org/pep-0723/) to the Python script, to document the Pydantic dependency and so users can run it without worrying about venvs and installing dependencies (e.g: by using `uv run script.py`)
* Update the deprecated Pydantic APIs to their supported alternatives
  * `Config.allow_population_by_field_name` -> `Config.validate_by_name` ([docs](https://docs.pydantic.dev/latest/migration/#changes-to-config))
  * `Config.schema_extra` -> `Config.json_schema_extra`  ([docs](https://docs.pydantic.dev/latest/migration/#changes-to-config))
  * `BaseModel.json_schema()` -> `BaseModel.model_json_schema()` ([docs](https://docs.pydantic.dev/latest/migration/#changes-to-pydanticbasemodel)
* Replace the JSON schema with the current output of the script
  * This makes the `title` and `description` fields for the predicate match what is actually specified in `Config.json_scheme_extra`, and also adds the `$id` and `$schema` fields, which were missing before


cc @wolfv 


for reference, here are the warning messages printed when running the original version of the script:
```
conda_orig/.venv/lib/python3.13/site-packages/pydantic/_internal/_config.py:373: UserWarning: Valid config keys have changed in V2:
* 'allow_population_by_field_name' has been renamed to 'validate_by_name'
* 'schema_extra' has been renamed to 'json_schema_extra'
  warnings.warn(message, UserWarning)
conda_orig/.venv/lib/python3.13/site-packages/pydantic/_internal/_config.py:373: UserWarning: Valid config keys have changed in V2:
* 'allow_population_by_field_name' has been renamed to 'validate_by_name'
  warnings.warn(message, UserWarning)
conda_orig/conda.py:162: PydanticDeprecatedSince20: The `schema` method is deprecated; use `model_json_schema` instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.11/migration/
  schema = CondaPublishAttestationPredicate.schema()

conda_orig/conda.py:184: PydanticDeprecatedSince20: The `schema` method is deprecated; use `model_json_schema` instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.11/migration/
```