### PR TITLE
Address a few review comments

### DIFF
--- a/cep-0027.md
+++ b/cep-0027.md
@@ -566,7 +566,7 @@ This CEP suggests that attestation verification be performed by
 both clients (i.e. package installers retrieving packages from
 attestation-aware channels) and servers (i.e. attestation-aware channels).
 
-Servers **SHOULD** perform the same verification process as clients,
+Servers **MUST** perform the same verification process as clients,
 with the qualification that the server's trust in the signing identity
 is established latently via the server's publishing and upload mechanism.
 For example, if the server supports [Trusted Publishing], then the package's

--- a/cep-0027.md
+++ b/cep-0027.md
@@ -127,7 +127,7 @@ seen adoption in similar and related ecosystems:
 This CEP proposes the following attestation statement layout, using the
 [in-toto Statement schema]:
 
-- `predicateType` **MUST** be `https://schemas.conda.org/attestations/publish/v1`
+- `predicateType` **MUST** be `https://schemas.conda.org/attestations-publish-1.schema.json`
 - `subject` **MUST** be a single [`ResourceDescriptor`], with the following
   constraints:
   - `subject[0].name` **MUST** be the full filename of the conda package
@@ -150,7 +150,7 @@ An example of a compliant statement is provided below:
         "name": "file-name-0.0.1-h123456_5.conda",
         "digest": {"sha256": "01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b"},
     }],
-    "predicateType": "https://schemas.conda.org/attestations/publish/v1",
+    "predicateType": "https://schemas.conda.org/attestations-publish-1.schema.json",
     "predicate": {
         "targetChannel": "https://prefix.dev/conda-forge",
     }
@@ -240,7 +240,7 @@ An example of a compliant statement is provided below:
       "type": "array"
     },
     "predicateType": {
-      "const": "https://schemas.conda.org/attestations/publish/v1",
+      "const": "https://schemas.conda.org/attestations-publish-1.schema.json",
       "description": "The predicate type for conda publish attestations",
       "title": "Predicatetype",
       "type": "string"
@@ -286,7 +286,7 @@ An example of a compliant statement is provided below:
 #
 """
 Pydantic model for the conda publish attestation predicate schema.
-This generates the JSON schema for https://schemas.conda.org/attestations/publish/v1
+This generates the JSON schema for https://schemas.conda.org/attestations-publish-1.schema.json
 """
 
 from typing import Annotated, Literal, Optional
@@ -318,7 +318,7 @@ class CondaPublishAttestationPredicate(BaseModel):
         # Generate schema with field aliases
         json_schema_extra = {
             "$schema": "https://json-schema.org/draft/2020-12/schema",
-            "$id": "https://schemas.conda.org/attestations/publish/v1",
+            "$id": "https://schemas.conda.org/attestations-publish-1.schema.json",
             "title": "Conda Publish Attestation Predicate",
             "description": (
                 "Predicate schema for conda publish attestations. "
@@ -420,7 +420,7 @@ class CondaPublishAttestationStatement(BaseModel):
         description="List containing exactly one ResourceDescriptor for the conda package"
     )
 
-    predicate_type: Literal["https://schemas.conda.org/attestations/publish/v1"] = Field(
+    predicate_type: Literal["https://schemas.conda.org/attestations-publish-1.schema.json"] = Field(
         alias="predicateType",
         description="The predicate type for conda publish attestations"
     )
@@ -441,7 +441,7 @@ def generate_predicate_schema() -> dict:
     # Update the schema to match the CEP requirements
     schema.update({
         "$schema": "https://json-schema.org/draft/2020-12/schema",
-        "$id": "https://schemas.conda.org/attestations/publish/v1",
+        "$id": "https://schemas.conda.org/attestations-publish-1.schema.json",
         "title": "Conda Publish Attestation Predicate",
         "description": (
             "JSON Schema for the predicate field of conda publish attestations. "
@@ -482,7 +482,7 @@ if __name__ == "__main__":
             "name": "file-name-0.0.1-h123456_5.conda",
             "digest": {"sha256": "01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b"},
         }],
-        "predicateType": "https://schemas.conda.org/attestations/publish/v1",
+        "predicateType": "https://schemas.conda.org/attestations-publish-1.schema.json",
         "predicate": {
             "targetChannel": "https://prefix.dev/conda-forge",
         }
@@ -542,7 +542,7 @@ This CEP recommends the following verification process:
 1. The verifier checks the in-toto statement for consistency against their
    ground truth:
 
-   - The `predicateType` field **MUST** be `https://schemas.conda.org/attestations/publish/v1`.
+   - The `predicateType` field **MUST** be `https://schemas.conda.org/attestations-publish-1.schema.json`.
    - The `subject[0].name` field **MUST** match the filename of the conda package.
    - The `subject[0].digest` field **MUST** match the SHA256 hash of the conda
      package.
@@ -673,7 +673,7 @@ future discussion and work:
     the PyPI and RubyGems ecosystems, e.g. [PyPI's Integrity API].
 
 3. This CEP specifies an single initial in-toto predicate
-   (`https://schemas.conda.org/attestations/publish/v1`), which conveys
+   (`https://schemas.conda.org/attestations-publish-1.schema.json`), which conveys
    a binding between a signing identity and its intent to publish
    a particular conda package to a particular channel.
 

--- a/cep-0027.md
+++ b/cep-0027.md
@@ -514,8 +514,9 @@ This CEP recommends the following signing process:
    attestation, and transparency log inclusion proof.
 
 Each of these steps is performed transparently by a Sigstore client like
-[sigstore-python], except for step (2) as it concerns the specific
-layout of the signed-over statement.
+[sigstore-python], except for the generation of the in-toto statement in
+step (2), which should be handled externally and then fed into the Sigstore
+client for signing.
 
 The result of this process is a single Sigstore bundle, which can be
 distributed alongside the conda package or otherwise made discoverable.

--- a/cep-0027.md
+++ b/cep-0027.md
@@ -521,7 +521,7 @@ client for signing.
 The result of this process is a single Sigstore bundle, which can be
 distributed alongside the conda package or otherwise made discoverable.
 
-This CEP does not proscribe a distribution mechanism; see
+This CEP does not define a distribution mechanism; see
 [Future work](#future-work).
 
 ### Verifying

--- a/cep-0027.md
+++ b/cep-0027.md
@@ -509,7 +509,7 @@ This CEP recommends the following signing process:
    produces an attestation by signing that statement with their ephemeral
    private key.
 3. The signer uploads their attestation to the Sigstore transparency log
-   as a [DSSE] envelope.
+   (the [Public Good Instance]) as a [DSSE] envelope.
 4. The signer produces a [Sigstore bundle] containing their certificate,
    attestation, and transparency log inclusion proof.
 
@@ -697,6 +697,7 @@ future discussion and work:
 [`ResourceDescriptor`]: https://github.com/in-toto/attestation/blob/main/spec/v1/resource_descriptor.md
 [`DigestSet`]: https://github.com/in-toto/attestation/blob/main/spec/v1/digest_set.md
 [DSSE]: https://github.com/secure-systems-lab/dsse/blob/master/envelope.md
+[Public Good Instance]: https://rekor.sigstore.dev/
 [Sigstore bundle]: https://docs.sigstore.dev/about/bundle/
 [sigstore-python]: https://github.com/sigstore/sigstore-python
 [Sigstore OID information]: https://github.com/sigstore/fulcio/blob/main/docs/oid-info.md

--- a/cep-0027.md
+++ b/cep-0027.md
@@ -95,9 +95,10 @@ in part or in full:
 - *Where* was this package *published from*, and where *to*?
 - *When* was this package published?
 
-However, this metadata is not currently **cryptographically verifiable**:
-the consuming party must either trust it as presented, or verify it manually
-against independent sources of truth (such as a project's release history).
+However, the authenticity of this metadata is not currently
+**cryptographically verifiable**: the consuming party must either trust it as
+presented, or verify it manually against independent sources of truth (such as
+a project's release history).
 
 Attestations that present this metadata in a cryptographically
 verifiable manner are desirable for a number of reasons:

--- a/cep-0027.md
+++ b/cep-0027.md
@@ -74,9 +74,9 @@ and will enable further integration with signing schemes like
       which in turn can be verified as authentically Alice's via the Fulcio-
       issued certificate.
 
-    With this flow, neither Alice nor Bob needs to maintain long-lived signing
-    or verifying keyrings, in turn reducing the attacker surface for key
-    compromise.
+  With this flow, neither Alice nor Bob needs to maintain long-lived signing
+  or verifying keyrings, in turn reducing the attacker surface for key
+  compromise.
 
   Another key misuse-resistance contribution within Sigstore is *machine
   identities*. A machine identity behaves similarly to a human identity


### PR DESCRIPTION
Addresses some of the PR's review coments

* Fix indentation
  *  https://github.com/conda/ceps/pull/112#discussion_r2155367152
* Reword the motivation to make explicit that what is currently not verifiable is a package's metadata **authenticity**, not the metadata itself (e.g: the hash is already verifiable)
  * https://github.com/conda/ceps/pull/112#discussion_r2155377416
* Fix `predicateType` url
  * https://github.com/conda/ceps/pull/112#discussion_r2155383044
* Clarify which Sigstore instance to use for the transparency log
  * https://github.com/conda/ceps/pull/112#discussion_r2155387672
* Clarify which signing steps are handled transparently by the Sigstore client
  * https://github.com/conda/ceps/pull/112#discussion_r2155388666
* `proscribe` -> `define` when mentioning that this CEP does not specify a distribution mechanism
  * https://github.com/conda/ceps/pull/112#discussion_r2155390090
* SHOULD -> MUST for servers having to perform the same verification process as clients
  * https://github.com/conda/ceps/pull/112#discussion_r2155398229


cc @wolfv @jezdez