### PR TITLE
fix last predicateType URL

### DIFF
--- a/cep-0027.md
+++ b/cep-0027.md
@@ -165,7 +165,7 @@ An example of a compliant statement is provided below:
 {
   "$defs": {
     "CondaPublishAttestationPredicate": {
-      "$id": "https://schemas.conda.org/attestations/publish/v1",
+      "$id": "https://schemas.conda.org/attestations-publish-1.schema.json",
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "description": "Predicate schema for conda publish attestations. This schema defines the structure of the predicate field in an in-toto statement for conda package publish attestations.",
       "properties": {


### PR DESCRIPTION
This one was leftover after the rebase of https://github.com/wolfv/ceps/pull/9 on top of https://github.com/wolfv/ceps/pull/8

cc @wolfv 