### PR TITLE
Remove redundant code and fix markdown lint warnings

### DIFF
--- a/cep-0027.md
+++ b/cep-0027.md
@@ -321,10 +321,11 @@ class CondaPublishAttestationPredicate(BaseModel):
             "$id": "https://schemas.conda.org/attestations-publish-1.schema.json",
             "title": "Conda Publish Attestation Predicate",
             "description": (
-                "Predicate schema for conda publish attestations. "
-                "This schema defines the structure of the predicate field in an in-toto "
-                "statement for conda package publish attestations."
-            )
+                "JSON Schema for the predicate field of conda publish attestations. "
+                "This schema defines the structure and validation rules for the predicate "
+                "portion of an in-toto statement used in conda package publish attestations, "
+                "as specified in CEP-0027."
+            ),
         }
 
 
@@ -436,23 +437,7 @@ class CondaPublishAttestationStatement(BaseModel):
 
 def generate_predicate_schema() -> dict:
     """Generate the JSON schema for the conda publish attestation predicate."""
-    schema = CondaPublishAttestationPredicate.model_json_schema()
-
-    # Update the schema to match the CEP requirements
-    schema.update({
-        "$schema": "https://json-schema.org/draft/2020-12/schema",
-        "$id": "https://schemas.conda.org/attestations-publish-1.schema.json",
-        "title": "Conda Publish Attestation Predicate",
-        "description": (
-            "JSON Schema for the predicate field of conda publish attestations. "
-            "This schema defines the structure and validation rules for the predicate "
-            "portion of an in-toto statement used in conda package publish attestations, "
-            "as specified in CEP-0027."
-        ),
-    })
-
-    return schema
-
+    return CondaPublishAttestationPredicate.model_json_schema()
 
 def generate_complete_statement_schema() -> dict:
     """Generate the JSON schema for the complete in-toto statement."""

--- a/cep-0027.md
+++ b/cep-0027.md
@@ -1,4 +1,4 @@
-# CEP - Standardizing a publish attestation for the conda ecosystem
+# CEP 27 - Standardizing a publish attestation for the conda ecosystem
 
 <table>
 <tr><td> Title </td><td> Standardizing a publish attestation for the conda ecosystem </td>

--- a/cep-0027.md
+++ b/cep-0027.md
@@ -167,7 +167,7 @@ An example of a compliant statement is provided below:
     "CondaPublishAttestationPredicate": {
       "$id": "https://schemas.conda.org/attestations-publish-1.schema.json",
       "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "description": "Predicate schema for conda publish attestations. This schema defines the structure of the predicate field in an in-toto statement for conda package publish attestations.",
+      "description": "JSON Schema for the predicate field of conda publish attestations. This schema defines the structure and validation rules for the predicate portion of an in-toto statement used in conda package publish attestations, as specified in CEP 27.",
       "properties": {
         "targetChannel": {
           "description": "The channel where the package is being uploaded to. This must be a valid URL with no trailing slashes.",

--- a/cep-0027.md
+++ b/cep-0027.md
@@ -28,8 +28,10 @@ and will enable further integration with signing schemes like
   - Alice signs a machine readable statement equivalent to the following
       English sentence, producing her attestation:
 
-        > Alice published the `widgets` package at version v1.2.3 with
-        > hash `sha256:abcd...` to the `conda-forge` channel.
+      ```text
+      > Alice published the `widgets` package at version v1.2.3 with
+      > hash `sha256:abcd...` to the `conda-forge` channel.
+      ````
 
   - Bob establishes trust in Alice's public key.
   - Bob can verify the attestation's signature against Alice's public key,

--- a/cep-0027.md
+++ b/cep-0027.md
@@ -299,7 +299,7 @@ class CondaPublishAttestationPredicate(BaseModel):
     Predicate for conda publish attestations.
 
     This represents the predicate portion of an in-toto statement for conda package
-    publish attestations, as defined in CEP-0027.
+    publish attestations, as defined in CEP 27.
     """
 
     target_channel: HttpUrl = Field(
@@ -324,7 +324,7 @@ class CondaPublishAttestationPredicate(BaseModel):
                 "JSON Schema for the predicate field of conda publish attestations. "
                 "This schema defines the structure and validation rules for the predicate "
                 "portion of an in-toto statement used in conda package publish attestations, "
-                "as specified in CEP-0027."
+                "as specified in CEP 27."
             ),
         }
 


### PR DESCRIPTION
This removes the code in `generate_predicate_schema()` that updates the JSON schema with the extra fields (`$id`, `description`, `$name`, `title`), since that is already taken care of by `Config.json_schema_extra`.

Since the description specified in `generate_predicate_schema()` and the one specified in `Config.json_schema_extra` were different, I made it so that the one in `generate_predicate_schema` was used, since it's the one that mentions this CEP by number:

```python
  "JSON Schema for the predicate field of conda publish attestations. "
  "This schema defines the structure and validation rules for the predicate "
  "portion of an in-toto statement used in conda package publish attestations, "
  "as specified in CEP 27."
```


This PR also fixes the remaining pre-commit linting errors, changing references to this CEP to follow the correct format (`CEP-0027` -> `CEP 27`), adding the CEP number to the document title, and making code blocks consistent.

cc @wolfv 