### PR TITLE
Remove duplicate `Specification` section

### DIFF
--- a/cep-0027.md
+++ b/cep-0027.md
@@ -17,15 +17,13 @@ This attestation layout is based on the [in-toto] framework
 and will enable further integration with signing schemes like
 [Sigstore].
 
-## Specification
-
-The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT",
-"RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as
-described in [RFC2119][RFC2119] when, and only when, they appear in all capitals, as shown here.
-
-More specifically, violations of a MUST or MUST NOT rule MUST result in an error. Violations of the
-rules specified by any of the other all-capital terms MAY result in a warning, at discretion of the
-implementation.
+> The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT",
+  "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as
+  described in [RFC2119][RFC2119] when, and only when, they appear in all capitals, as shown here.
+>
+> More specifically, violations of a MUST or MUST NOT rule MUST result in an error. Violations of the
+  rules specified by any of the other all-capital terms MAY result in a warning, at discretion of the
+  implementation.
 
 ## Definitions and Concepts
 


### PR DESCRIPTION
The "Specification" section already exists, move the `RFC2119` text to the abstract (like [this CEP](https://github.com/trail-of-forks/ceps/blob/2ee2fb3d96e7008b59e93964a7f78667bb51d6c2/cep-0022.md?plain=1#L18-L20))

cc @wolfv 