### PR TITLE
Formalize and clarify the CEP

### DIFF
--- a/cep-XXXX.md
+++ b/cep-XXXX.md
@@ -16,7 +16,7 @@
 
 This CEP defines staging outputs for v1 multi-output recipes.
 
-## Background
+## Motivation
 
 Sometimes it is very useful to build some code once, and then split it into multiple build artifacts (such as shared library, header files, etc.). For this reason, `conda-build` has a special, implicit top-level build.
 

--- a/cep-XXXX.md
+++ b/cep-XXXX.md
@@ -63,14 +63,16 @@ Inheriting from the top-level is a special case of regular "staging" inheritance
 
 A new `build.files` field is added to package outputs. It can be used to restrict which files from `$PREFIX` are included in the package output.
 
-When the field is not present, all new files are included. When it is present, it MUST either be:
+When the field is not present, the output follows the usual rules for determining the files to include.
+
+When it is present, it MUST either be:
 
 - a list of include patterns
 - a map with at least one of the following keys:
-  - `include` specifying a list of include patterns
-  - `exclude` specifying a list of exclude patterns
+  - `include` specifying a list of include patterns (defaults to `[**]`)
+  - `exclude` specifying a list of exclude patterns (defaults to empty)
 
-TODO: include / exclude logic
+In other to determine the files to include in a package output, the implementation MUST first determine the list of new files in the `$PREFIX`. This list MUST then be filtered to include only files matching at least one of the include patterns. Afterwards, all files matching at least one of the exclude patterns MUST be removed from it.
 
 ### Example
 

--- a/cep-XXXX.md
+++ b/cep-XXXX.md
@@ -49,7 +49,7 @@ When present, the `inherit` field MUST have one of the three following values:
   - a REQUIRED `from` key, specifying the name of the output to inherit from, as a string
   - an OPTIONAL `run_exports` key, whose value is a boolean, specifying whether to inherit `run_exports` (defaults to true)
 
-Both staging and package outputs MAY inherit, however, a staging output MUST NOT inherit from a package output.
+A package output MAY inherit from a staging or another package output. However, a staging output MAY only inherit from another staging output.
 
 When inheriting, values from `build` and `about` sections MUST be deeply merged with the values from the inherited output, except for the value of `build.script`.
 

--- a/cep-XXXX.md
+++ b/cep-XXXX.md
@@ -47,7 +47,7 @@ When present, the `inherit` field MUST have one of the three following values:
 - a string specifying the output to inherit from
 - a map, with the following keys:
   - a REQUIRED `from` key, specifying the output to inherit from, as a string
-  - an OPTIONAL `run_exports` key, specifying whether to inherit `run_exports` (defaults to true)
+  - an OPTIONAL `run_exports` key, whose value is a boolean, specifying whether to inherit `run_exports` (defaults to true)
 
 Both staging and package outputs MAY inherit, however, a staging output MUST NOT inherit from a package output.
 

--- a/cep-XXXX.md
+++ b/cep-XXXX.md
@@ -44,9 +44,9 @@ A new `inherit` field is added to both staging and package outputs. When present
 When present, the `inherit` field MUST have one of the three following values:
 
 - `null` indicating "top-level" inheritance (the default, when no `inherit` field is present)
-- a string specifying the output to inherit from
+- a string specifying the name of the output to inherit from (as defined in the `staging.name` or `package.name` field)
 - a map, with the following keys:
-  - a REQUIRED `from` key, specifying the output to inherit from, as a string
+  - a REQUIRED `from` key, specifying the name of the output to inherit from, as a string
   - an OPTIONAL `run_exports` key, whose value is a boolean, specifying whether to inherit `run_exports` (defaults to true)
 
 Both staging and package outputs MAY inherit, however, a staging output MUST NOT inherit from a package output.

--- a/cep-XXXX.md
+++ b/cep-XXXX.md
@@ -53,7 +53,7 @@ A package output MAY inherit from a staging or another package output. However, 
 
 When inheriting, values from `build` and `about` sections MUST be deeply merged with the values from the inherited output, except for the value of `build.script`.
 
-Requirements MUST NOT be inherited. However, `run_exports` MUST be, unless the `run_exports` key is set to `false` in the `inherit` map. The implementation MUST support ignoring Specific run-exports either in the staging output or in the package output (both follow the same rules).
+Requirements MUST NOT be inherited. However, `run_exports` MUST be, unless the `run_exports` key is set to `false` in the `inherit` map. The implementation MUST support ignoring specific `run_exports` either in the staging output or in the package output (both follow the same rules).
 
 ### Top-level inheritance
 
@@ -134,7 +134,7 @@ outputs:
 
 When computing variants and used variables, the implementation MUST look at the union of a given output and the outputs it inherits from. That means, even if a package output does not define any requirements, the inherited staging output could introduce variants. In the example, the `foo-cache` output would add a variant for the `c_compiler`.
 
-When executing the recipe, the implementation MUST build the inherited outputs that are appropriate for the current variant first. This is computed by looking at all "used-variables" for the inherited output and computing a "hash" for it. The build itself MUST be executed in the same way as any other build.
+When executing the recipe, the implementation MUST build the inherited outputs that are appropriate for the current variant first. This is computed by looking at all "used variables" for the inherited output and computing a "hash" for it. The build itself MUST be executed in the same way as any other build.
 
 The variant keys that are injected at build time are the subset used by the inherited output.
 

--- a/cep-XXXX.md
+++ b/cep-XXXX.md
@@ -10,9 +10,11 @@
 <tr><td> Implementation </td><td> rattler-build </td></tr>
 </table>
 
+> The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC2119][RFC2119] when, and only when, they appear in all capitals, as shown here.
+
 ## Abstract
 
-This CEP aims to define the staging output for v1 multi-output recipes.
+This CEP defines staging outputs for v1 multi-output recipes.
 
 ## Background
 
@@ -24,9 +26,55 @@ For the v1 spec we are attempting to formalize the workings of the "top-level" b
 
 ## Specification
 
-A recipe can have zero or more staging outputs.
+[CEP 13](./cep-0013.md) and [CEP 14](./cep-0014.md) define the v1 recipe format. This CEP extends these specifications by introducing _staging outputs_ that can exist alongside _package outputs_.
 
-A staging output looks as follows:
+### Staging outputs
+
+A recipe can have zero or more staging outputs. A staging output is defined in the outputs section, and differs from a regular output in the following ways:
+
+- The `package` subsection MUST NOT be present
+- A `staging` subsection MUST be present, with a single key `name`. The value MUST be a string, following same rules as `package.name`. Every name MUST be unique among all package and staging outputs.
+- In the `requirements` subsection, the `run` and `run_constraints` fields MUST NOT be present.
+- In the `build` subsection, no other fields than `script` MUST be present.
+
+### Outputs inheritance
+
+A new `inherit` field is added to both staging and package outputs. When present, it MAY specify an output to inherit from.
+
+When present, the `inherit` field MUST have one of the three following values:
+
+- `null` indicating "top-level" inheritance (the default, when no `inherit` field is present)
+- a string specifying the output to inherit from
+- a map, with the following keys:
+  - a REQUIRED `from` key, specifying the output to inherit from, as a string
+  - an OPTIONAL `run_exports` key, specifying whether to inherit `run_exports` (defaults to true)
+
+Both staging and package outputs MAY inherit, however, a staging output MUST NOT inherit from a package output.
+
+When inheriting, values from `build` and `about` sections MUST be deeply merged with the values from the inherited output, except for the value of `build.script`.
+
+Requirements MUST NOT be inherited. However, `run_exports` MUST be, unless the `run_exports` key is set to `false` in the `inherit` map. The implementation MUST support ignoring Specific run-exports either in the staging output or in the package output (both follow the same rules).
+
+### Top-level inheritance
+
+Inheriting from the top-level is a special case of regular "staging" inheritance. If the output does not specify any `inherit` key or explicitly sets `inherit: null` then the output inherits from the top-level. The `recipe.version`, `source`, `build` and `about` top-level fields MUST be applied to the output. In the case of top-level inheritance, `requirements` and `build.script` are forbidden and thus ignored. This unifies the rules for both staging and top-level.
+
+### File filtering
+
+A new `build.files` field is added to package outputs. It can be used to restrict which files from `$PREFIX` are included in the package output.
+
+When the field is not present, all new files are included. When it is present, it MUST either be:
+
+- a list of include patterns
+- a map with at least one of the following keys:
+  - `include` specifying a list of include patterns
+  - `exclude` specifying a list of exclude patterns
+
+TODO: include / exclude logic
+
+### Example
+
+A recipe with staging output looks as follows:
 
 ```yaml
 outputs:
@@ -80,84 +128,18 @@ outputs:
         - ${{ pin_subpackage("foo-headers", exact=True) }}
 ```
 
-> [!WARNING]
-> When using `outputs` we are going to remove the implicit `build.script` pointing to `script.sh`. Going forward, the script name / content has to be set explicitly.
+### Building outputs
 
-When computing variants and used variables, rattler-build looks at the union of a given `output` and the `staging` cache. That means, even if an output does not define any requirements, the `staging` cache would still add a variant for the `c_compiler`.
+When computing variants and used variables, the implementation MUST look at the union of a given output and the outputs it inherits from. That means, even if a package output does not define any requirements, the inherited staging output could introduce variants. In the example, the `foo-cache` output would add a variant for the `c_compiler`.
 
-When rattler-build executes the recipe, it will start by building the `staging` cache outputs that are appropriate for the current variant. This is computed by looking at all "used-variables" for the `staging` cache output and computing a "hash" for it. The build itself is executed in the same way as any other build.
+When executing the recipe, the implementation MUST build the inherited outputs that are appropriate for the current variant first. This is computed by looking at all "used-variables" for the inherited output and computing a "hash" for it. The build itself MUST be executed in the same way as any other build.
 
-The variant keys that are injected at build time is the subset used by the `staging` output.
+The variant keys that are injected at build time are the subset used by the inherited output.
 
-When the `staging` build is done, the newly created files are moved outside of the `host-prefix`. Post-processing is not performed on the files beyond memoizing what files contain the `$PREFIX` (which is later replaced in binaries and text files with the actual build-prefix).
+When the build of an inherited output is done, the newly created files MUST be moved outside of the `host-prefix`. Post-processing MUST NOT be performed on the files beyond memorizing what files contain the `$PREFIX` (which is later replaced in binaries and text files with the actual build-prefix). The host environment (`$PREFIX`) and the source directory MUST be restored to the original state, including reverting any changes that were made by the build script.
 
-The staging output restores files that were added to the host environment (`$PREFIX`) and the "dirty" source directory, including any changes that were made by the build script. They are cloned to a special staging location from which they are restored.
+When the inheriting output is being built, these changes MUST be restored. If the two builds were not running in the same exact location, the path leading up to the work directory and the host prefix MUST be replaced in the inherited artifacts (for example when running time-stamped builds in folders such as `/folder/to/bld/libfoo_1745399500/{work_dir,h_env_...}`).
 
-If the `staging` build and the package build are not running in the same exact location, the path leading up to the work dir / host prefix needs to be replaced in the `staging` artifacts (for example when running time-stamped builds in folders such as `/folder/to/bld/libfoo_1745399500/{work_dir,h_env_...}`).
+When a package output adds a `source` and inherits from an output, the user is responsible not to clobber files (e.g. by using `target_directory`). The build program SHOULD warn if files are overwritten in the work directory.
 
-When a package output adds a `source` and inherits from a staging output, care must be taken by the user to not clobber files (e.g. by using `target_directory`). The build program should warn if files are overwritten in the work dir.
-
-New files in the prefix (from the staging output) can be used in the outputs with the `build.files` key:
-
-```yaml
-outputs:
-  - staging:
-      name: foo-cache
-
-  - package:
-      name: foo-headers
-      version: "1.0.0"
-
-    inherit:
-      from: foo-cache
-      run_exports: false
-
-    build:
-      files:
-        - include/**
-
-  - package:
-      name: libfoo
-      version: "1.0.0"
-
-    inherit: foo-cache
-
-    build:
-      files:
-        - lib/**
-
-  - package:
-      name: foo-devel
-      version: "1.0.0"
-
-    inherit: foo-cache
-
-    requirements:
-      run:
-        - ${{ pin_subpackage("libfoo") }}
-        - ${{ pin_subpackage("foo-headers") }}
-```
-
-The glob list syntax can also be a dictionary with `include / exclude` keys, e.g.
-
-```yaml
-files:
-  include:
-    - include/**
-  exclude:
-    - lib/**
-```
-
-## The `inherit` key and the logic of inheritance
-
-The `inherit` key is used to inherit from a staging output. We also generalize the logic to "top-level" inheritance, which is what happens when the inherit key is set to `null`.
-
-Both, `staging` and `package` outputs can inherit, however, a `staging` cannot inherit from a `package`.
-
-When inheriting, values from `build` and `about` are deeply merged with the values from the staging output, except for the value of `build.script`.
-
-Requirements are not inherited, however, `run_exports` are. The inheritance of `run_exports` can be disabled by setting the `run_exports` key to `false` in the `inherit` map. To ignore certain run-exports they can be either ignored in the staging output or in the package output (both follow the same rules).
-
-### Top-level inheritance
-
-Inheriting from the top-level is a special case of regular "staging" inheritance. If the output does not specify any `inherit` key or explicitly sets `inherit: null` then we inherit from the top-level and apply `recipe.version`, `source`, `build` and `about` from the top-level to each output. In the case of top-level inheritance, requirements and build script are forbidden and thus ignored. This unifies the rules for both staging and top-level.
+New files in the prefix (from the staging output) can be used in the outputs with the `build.files` key.

--- a/cep-XXXX.md
+++ b/cep-XXXX.md
@@ -32,7 +32,7 @@ For the v1 spec we are attempting to formalize the workings of the "top-level" b
 
 A recipe can have zero or more staging outputs. A staging output is defined in the outputs section, and differs from a regular output in the following ways:
 
-- The `package` subsection MUST NOT be present
+- The `package` subsection MUST NOT be present.
 - A `staging` subsection MUST be present, with a single key `name`. The value MUST be a string, following same rules as `package.name`. Every name MUST be unique among all package and staging outputs.
 - In the `requirements` subsection, the `run` and `run_constraints` fields MUST NOT be present.
 - In the `build` subsection, no other fields than `script` MUST be present.


### PR DESCRIPTION
CC @wolfv, @jaimergp

This is my first approximation. I've tried to make it very formal, perhaps even too much. I've reordered things a bit, so that we specify the new YAML keys first, then give an example, then describe the behavior in detail.

That said, I'm not sure if we really need to formally define all this behavior, or if some of it is implicit from the assumptions above and can be left non-normative.

I've left a TODO for the `build.files` field, since I need some clarification of how it actually works. I suppose we also need to clarify how files are selected for subsequent outputs, given the note in the example.